### PR TITLE
Use https due to new 302 redirects

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -119,7 +119,7 @@ var main = {
   translatePage: function(url) {
     var lang = main.settings("language");
     if (main.validURL(url)) {
-        var translateUrl = "http://translate.google.com/translate?js=n&prev=_t&ie=UTF-8&tl=" + encodeURIComponent(lang) + "&u=" + encodeURIComponent(url);
+        var translateUrl = "https://translate.google.com/translate?js=n&prev=_t&ie=UTF-8&tl=" + encodeURIComponent(lang) + "&u=" + encodeURIComponent(url);
         if (main.settings("newTab")) {
              tabs.open(translateUrl);
         } else {
@@ -136,7 +136,7 @@ var main = {
     if (text.length === 0) {
       main.notify("Uh Oh!", "Looks like you selected empty text, try again");
     } else {
-        var url = "http://translate.google.com/#auto/" + encodeURIComponent(lang) + "/" + encodeURIComponent(text);
+        var url = "https://translate.google.com/#auto/" + encodeURIComponent(lang) + "/" + encodeURIComponent(text);
         if (main.settings("newTab")) {
             tabs.open(url);
         } else {


### PR DESCRIPTION
Google are now issuing 302 redirects from `http://translate.google.com/` to `https://translate.google.com/`. Trouble is, the being passed in is lost in the redirect, so the plugin has stopped working (for me at least). It works if I change the target url to `https://` instead.

PS> Thanks for a handy plugin, real time saver for expats :+1: 
